### PR TITLE
Rename 'exlude' to 'exclude'

### DIFF
--- a/bulktest/tests.py
+++ b/bulktest/tests.py
@@ -174,7 +174,7 @@ class UpdateTest(TestCase):
         self.assertEqual(n.b, 2)
         self.assertEqual(n.c, 1)
 
-    def test_update_exlude_field(self):
+    def test_update_exclude_field(self):
         """Exclude update b field"""
         n = TestModelA(a="Test", b=1, c=1)
         n.save()
@@ -255,7 +255,7 @@ class InsertUpdateTest(TestCase):
             ]
 
         insert_or_update_many(TestModelA, set2, keys=['a'],
-                              exlude_fields=['c'])
+                              exclude_fields=['c'])
         self.assertEqual(3, TestModelA.objects.all().count())
 
         self.assertEqual(1, TestModelA.objects.get(a="Test1", b=1).c)

--- a/djangobulk/bulk.py
+++ b/djangobulk/bulk.py
@@ -212,7 +212,7 @@ def _filter_objects(con, objects, key_fields):
 @transaction_management
 def insert_or_update_many(model, objects, keys=None, using="default",
                           skip_update=False, update_fields=[],
-                          exlude_fields=[]):
+                          exclude_fields=[]):
     '''
     Bulk insert or update a list of Django objects. This works by
     first selecting each object's keys from the database. If an
@@ -274,7 +274,7 @@ def insert_or_update_many(model, objects, keys=None, using="default",
             using=using,
             skip_result=False,
             update_fields=update_fields,
-            exclude_fields=exlude_fields
+            exclude_fields=exclude_fields
         )
 
     # Find the objects that need to be inserted.


### PR DESCRIPTION
Fixes a typo in `insert_or_update_many` for the new field `exclude_fields`.
This typo shouldn't have any effect since it's not currently used.